### PR TITLE
Switch to ksoc docker image with grype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM us.gcr.io/ksoc-public/image-scan:0.0.2
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ jobs:
           push: false
           load: true
       - name: KSOC Image Scan
-        uses: ksoclabs/image-scan-action@v0.0.1
+        uses: ksoclabs/image-scan-action@v0.0.2
         with:
           image: "localbuild/testimage:latest"
+          fail_on_severity: "medium"
 ```
 
-Above example shows how to build a local image and scan it for CVEs. By default, it will fail if CVEs with severity `high` or `critical` are found. This can be changed by setting the `fail_on_severity` input to a different severity level.
+Above example shows how to build a local image and scan it for CVEs. It will fail the workflow if any CVE with `medium` severity is found. If `fail_on_severity` input is not provided, the action won't fail.
 
 ## Inputs
 
 - `image`: The image to scan. This is a required input.
-- `fail_on_severity`: The severity level that will cause the action to fail. If not provided, the action will fail if `high` or `critical` severity CVEs are found.
+- `fail_on_severity`: The severity level that will cause the action to fail. If not provided, the action doesn't fail. Possible values are `negligible`, `low`, `medium`, `high` and `critical`.

--- a/action.yaml
+++ b/action.yaml
@@ -9,15 +9,13 @@ inputs:
   fail_on_severity:
     required: false
     description: "The severity level at which to fail the workflow. Valid values are: negligible, low, medium, high, critical."
-    default: high
   image:
     required: false
     description: "Image to scan."
 
 runs:
   using: docker
-  image: docker://anchore/grype:v0.61.0
-  args:
-    - ${{ inputs.image }}
-    - -f
-    - ${{ inputs.fail_on_severity }}
+  image: Dockerfile
+  env:
+    FAIL_ON_SEVERITY: ${{ inputs.fail_on_severity }}
+    IMAGE: ${{ inputs.image }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -l
+
+[ -z ${FAIL_ON_SEVERITY} ] || PARAM_FAIL_ON_SEVERITY="-f ${FAIL_ON_SEVERITY}"
+
+/grype ${PARAM_FAIL_ON_SEVERITY} ${IMAGE}


### PR DESCRIPTION
Switching to custom docker image that is based on Alpine will allow us to override entrypoint and add custom parsing of Grype output.