### PR TITLE
Update base imagescan Docker layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/ksoc-public/image-scan:0.0.2
+FROM us.gcr.io/ksoc-public/image-scan:0.0.3
 
 RUN apk add --no-cache jq
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
Update the base image-scan layer for performance improvements.  In some instances, the image scan step would get stuck due to data volume issues.

Also update Renovate to enable more recommended actions.